### PR TITLE
Refactor concat benchmark

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "source-directories": [
         "src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
             "elm/core": "1.0.2",

--- a/src/Fusion.elm
+++ b/src/Fusion.elm
@@ -1,4 +1,4 @@
-module ListConcat exposing (main)
+module Fusion exposing (main)
 
 import Benchmark exposing (Benchmark, benchmark, describe)
 import Benchmark.Runner exposing (BenchmarkProgram, program)

--- a/src/ListConcat.elm
+++ b/src/ListConcat.elm
@@ -22,9 +22,16 @@ suite =
 
 
 mkBench : String -> ( Int, Int ) -> (List (List Int) -> List Int) -> Benchmark
-mkBench functionName ( m, n ) concatFuction =
-    benchmark (functionName ++ " (" ++ String.fromInt m ++ " lists of lenth " ++ String.fromInt n ++ ")") <|
-        \() -> concatFuction (mkList m n)
+mkBench functionName ( m, n ) =
+    let
+        list =
+            mkList m n
+
+        title =
+            functionName ++ " (" ++ String.fromInt m ++ " lists of lenth " ++ String.fromInt n ++ ")"
+    in
+    \concatFuction ->
+        benchmark title <| \() -> concatFuction list
 
 
 fastConcat : List (List a) -> List a


### PR DESCRIPTION
please see https://github.com/jhrcek/elm-benchmarks/pull/1 first.

Previously the construction of long list was part of benchmark of the 2 concat implementation. I think it's better to exclude them to make sure we're measuring just the performance of concat itself.

before:
![image](https://user-images.githubusercontent.com/2130305/79448260-69588700-7fe1-11ea-92af-0fcb109eb419.png)

after:
![image](https://user-images.githubusercontent.com/2130305/79448289-77a6a300-7fe1-11ea-857c-5dd2edf7bc68.png)
